### PR TITLE
Better githook creation; Command to disable githook

### DIFF
--- a/src/Console/DisableGitHookCommand.php
+++ b/src/Console/DisableGitHookCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Codimais\AppVer\Console;
+
+use Illuminate\Console\Command;
+use Codimais\AppVer\AppVer;
+
+class DisableGitHookCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'appver:dishook';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Disable the githook pre-commit instructions.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(): int
+    {
+        $appver = new AppVer();
+
+        $appver->removeGitHook();
+
+        $this->line(' ');
+        $this->info('AppVer');
+        $this->info(">> GitHook instruction removed");
+        $this->line(' ');
+
+        return 0;
+    }
+}


### PR DESCRIPTION
Now, the pre-commit hook will be checked, so we can add our instruction without destroying anything already existing.
A new command to disable our pre-commit instructions.